### PR TITLE
Fix 'list' command segementation fault

### DIFF
--- a/nvme-topology.c
+++ b/nvme-topology.c
@@ -357,9 +357,9 @@ static int verify_legacy_ns(struct nvme_namespace *n)
 		char tmp_address[64] = "";
 		legacy_get_pci_bdf(path, tmp_address);
 		if (tmp_address[0]) {
-			if (asprintf(&n->ctrl->transport, "pcie") != 1)
+			if (asprintf(&n->ctrl->transport, "pcie") < 0)
 				return -1;
-			if (asprintf(&n->ctrl->address, "%s", tmp_address) != 1)
+			if (asprintf(&n->ctrl->address, "%s", tmp_address) < 0)
 				return -1;
 		}
 	}

--- a/nvme-topology.c
+++ b/nvme-topology.c
@@ -148,7 +148,7 @@ static int scan_namespace(struct nvme_namespace *n)
 	if (ret < 0)
 		return ret;
 
-	fd = open(path, O_RDONLY);
+	fd = open_global_device(path);
 	if (fd < 0)
 		goto free;
 
@@ -160,7 +160,7 @@ static int scan_namespace(struct nvme_namespace *n)
 	if (ret < 0)
 		goto close_fd;
 close_fd:
-	close(fd);
+	close_global_device();
 free:
 	free(path);
 	return 0;
@@ -364,14 +364,14 @@ static int verify_legacy_ns(struct nvme_namespace *n)
 		}
 	}
 
-	fd = open(path, O_RDONLY);
+	fd = open_global_device(path);
 	free (path);
 
 	if (fd < 0)
 		return fd;
 
 	ret = nvme_identify_ctrl(fd, &id);
-	close(fd);
+	close_global_device();
 
 	if (ret)
 		return ret;
@@ -426,10 +426,10 @@ static int legacy_list(struct nvme_topology *t)
 			continue;
 		ret = 0;
 
-		fd = open(path, O_RDONLY);
-		if (fd > 0) {
+		fd = open_global_device(path);
+		if (fd >= 0) {
 			nvme_identify_ctrl(fd, &c->id);
-			close(fd);
+			close_global_device();
 		}
 		free(path);
 

--- a/nvme.h
+++ b/nvme.h
@@ -107,4 +107,7 @@ void free_topology(struct nvme_topology *t);
 char *get_nvme_subsnqn(char *path);
 char *nvme_get_ctrl_attr(char *path, const char *attr);
 
+int open_global_device(char *dev);
+int close_global_device();
+
 #endif /* _NVME_H */

--- a/plugins/microchip/rc-nvme-device.h
+++ b/plugins/microchip/rc-nvme-device.h
@@ -28,6 +28,7 @@
 #include "nvme-device.h"
 
 struct rc_nvme_device {
+	int fd;
 	struct nvme_device device;
 };
 


### PR DESCRIPTION
Caused by several bugs: 
- device not opened properly in legacy_list function
- sprintf return code checking bug from upstream nvme-cli code
- file status not updated properly
