### PR TITLE
Fix firmware download command errors

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -2318,8 +2318,8 @@ static int fw_download(int argc, char **argv, struct command *cmd, struct plugin
 	}
 
 	buf = fw_buf;
-	if (cfg.xfer == 0 || cfg.xfer % 4096)
-		cfg.xfer = 4096;
+
+	cfg.xfer = 512;
 	if (read(fw_fd, fw_buf, fw_size) != ((ssize_t)(fw_size))) {
 		err = -errno;
 		fprintf(stderr, "read :%s :%s\n", cfg.fw, strerror(errno));

--- a/nvme.c
+++ b/nvme.c
@@ -178,7 +178,6 @@ int open_global_device(char *dev)
 		if (!pax->dev) {
 			switchtec_perror(device_str);
 			free(pax);
-			printf("return here\n");
 			global_device  = NULL;
 			return -ENODEV;
 		}


### PR DESCRIPTION
Due to a limitation in Switchtec firmware, `fw-download` command can only support chunk size <1024 bytes. 

512 has been found to be the maximum chunk size that currently works with `fw-download` command.

