### PR TITLE
Fix namespace info display issue in 'switchtec list' command

### DIFF
--- a/plugins/microchip/switchtec-nvme.c
+++ b/plugins/microchip/switchtec-nvme.c
@@ -79,7 +79,7 @@ int get_nvme_info(int fd, struct list_item *item, const char *node)
 	if (item->nsid <= 0)
 		return item->nsid;
 	err = nvme_identify_ns(fd, item->nsid,
-			       0, &item->ns);
+			       1, &item->ns);
 	if (err)
 		return err;
 	strcpy(item->node, node);


### PR DESCRIPTION
Need to set 'present' flag to ensure nvme_identify_ns returns current namespace information