### PR TITLE
Fix device enumeration for 'switchtec list' command

### DIFF
--- a/plugins/microchip/switchtec-nvme.c
+++ b/plugins/microchip/switchtec-nvme.c
@@ -271,9 +271,10 @@ static int pax_get_nvme_pf_functions(struct pax_nvme_device *pax,
 	struct switchtec_gfms_db_ep_port_attached_device_function *functions,
 	int max_functions)
 {
-	int i;
+	int i, j;
 	int index;
 	int ret;
+	int n;
 	struct switchtec_gfms_db_pax_all pax_all;
 	struct switchtec_gfms_db_ep_port *ep_port;
 	struct switchtec_gfms_db_ep_port_ep *ep;
@@ -290,6 +291,17 @@ static int pax_get_nvme_pf_functions(struct pax_nvme_device *pax,
 			ret = pax_enum_ep(ep, functions + index,
 					  max_functions - index);
 			index += ret;
+		} else if (ep_port->port_hdr.type ==
+			   SWITCHTEC_GFMS_DB_TYPE_SWITCH) {
+			n = ep_port->port_hdr.ep_count;
+
+			for (j = 0; j < n; j++) {
+				ep = ep_port->ep_switch.switch_eps + j;
+				ret = pax_enum_ep(ep, functions + index,
+						  max_functions - index);
+
+				index += ret;
+			}
 		}
 	}
 


### PR DESCRIPTION
Add support for enumerating devices under downstream switch and/or remote PAX.

The enumeration process contains several loops and is thus divided into several functions:
1. loop through all devices (/dev/switchtec0, 1, ...n), this is done in function `switchtec_pax_list`
2. for each device, loop through all connected PAX (PAX0 - 31), this is done in function `pax_get_nvme_pf_list`
3. for each PAX, loop through all EPs, and for EP that are `ep_type_switch`, further loop through each downstream EP, this is done in function `pax_get_nvme_pf_functions`
4. for each EP from above, loop through all VFs, this is done in function `pax_enum_ep`

The above 3-4 step generates a list of functions, which is used to populate the list of `list_items`, in function `pax_build_nvme_pf_list`.

