### PR TITLE
Add 'switchtec vf-reset' command

### DIFF
--- a/plugins/microchip/switchtec-nvme.h
+++ b/plugins/microchip/switchtec-nvme.h
@@ -33,6 +33,7 @@
 PLUGIN(NAME("switchtec", "Switchtec specific extensions"),
 	COMMAND_LIST(
 		ENTRY("list", "List all NVMe devices and namespaces attached to Switchtec PAX switches", switchtec_pax_list)
+		ENTRY("vf-reset", "Perform a Function Level Reset (FLR) on a Virtual Function", switchtec_vf_reset)
 	)
 );
 


### PR DESCRIPTION
This command requests a function-level reset (FLR) for a VF.

Starting from offset given by configuration space offset 0x34, we search for data structure with `CAPABILITY=0x10`, till we reach `next_offset=0` (end of linked list). 

If a structure with 0x10 is found, we write a 1 to bit 15 of `offset+8`.


Data structures:
```
CFG Space
--------------- 
... offset @0x34
...
----------------

PCIe Cap structure
----------------------------------
Next offset (@offset+1) | Cap ID (@offset+0)
------------------------------
...
Device_Ctrl @offset+8
-----------------------------
```


