### PR TITLE
Fix 'switchtec list' double free memory issue

### DIFF
--- a/plugins/microchip/switchtec-nvme.c
+++ b/plugins/microchip/switchtec-nvme.c
@@ -486,6 +486,7 @@ static int switchtec_pax_list(int argc, char **argv, struct command *command,
 		if (ret > 0)
 			index += ret;
 
+		global_device = NULL;
 		switchtec_close(pax->dev);
 		free(pax);
 	}


### PR DESCRIPTION
Set 'global_device' to NULL after use in function switchtec_pax_list.

The new code goes :
```
		pax = malloc(sizeof(struct pax_nvme_device));
		pax->device.ops = &pax_ops;
		pax->dev = switchtec_open(path);
		...

		global_device = &pax->device;

		ret = pax_get_nvme_pf_list(pax, list_items + index, path);
		if (ret > 0)
			index += ret;

		global_device = NULL;
		switchtec_close(pax->dev);
		free(pax);
```