### PR TITLE
Remove NSID field from switchtec device name

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -171,7 +171,6 @@ int open_global_device(char *dev)
 		pax = malloc(sizeof(struct pax_nvme_device));
 		pax->pdfid = pdfid;
 		pax->device.ops = &pax_ops;
-		pax->is_blk = 0;
 
 		pax->dev = switchtec_open(device_str);
 		if (!pax->dev) {

--- a/nvme.c
+++ b/nvme.c
@@ -153,26 +153,25 @@ int open_global_device(char *dev)
 	int err, fd;
 	char device_str[64];
 	char pdfid_str[64];
-	uint16_t pdfid;
-	uint32_t ns_id;
+	long pdfid;
+	char *end;
 	struct pax_nvme_device *pax;
 	struct rc_nvme_device *rc;
-	int n;
 
 	devicename = basename(dev);
 
 	if (sscanf(dev, "%2049[^@]@%s", pdfid_str, device_str) == 2) {
-		n = sscanf(pdfid_str, "%hxn%d", &pdfid, &ns_id);
-		if (!n) {
-			return -1;
+		errno = 0;
+		pdfid = strtol(pdfid_str, &end, 0);
+		if(*end || errno || (pdfid < 0 || pdfid > 0xffff)) {
+			fprintf(stderr, "Invalid device %s\n", dev);
+			return -ENODEV;
 		}
+
 		pax = malloc(sizeof(struct pax_nvme_device));
 		pax->pdfid = pdfid;
 		pax->device.ops = &pax_ops;
-		if (n == 2) {
-			pax->is_blk = 1;
-			pax->ns_id = ns_id;
-		}
+		pax->is_blk = 0;
 
 		pax->dev = switchtec_open(device_str);
 		if (!pax->dev) {

--- a/plugins/microchip/switchtec-nvme-device.c
+++ b/plugins/microchip/switchtec-nvme-device.c
@@ -221,10 +221,7 @@ int pax_nvme_submit_io_passthru(int fd, struct nvme_passthru_cmd *cmd)
 
 int pax_is_blk(void)
 {
-	struct pax_nvme_device *pax;
-	pax = to_pax_nvme_device(global_device);
-
-	return pax->is_blk;
+	return 0;
 }
 
 int pax_nvme_get_nsid(int fd)

--- a/plugins/microchip/switchtec-nvme-device.c
+++ b/plugins/microchip/switchtec-nvme-device.c
@@ -229,10 +229,8 @@ int pax_is_blk(void)
 
 int pax_nvme_get_nsid(int fd)
 {
-	struct pax_nvme_device *pax;
-	pax = to_pax_nvme_device(global_device);
-
-	return pax->ns_id;
+	errno = -ENOTBLK;
+	return -1;
 }
 
 struct nvme_device_ops pax_ops = {

--- a/plugins/microchip/switchtec-nvme-device.h
+++ b/plugins/microchip/switchtec-nvme-device.h
@@ -33,7 +33,6 @@
 struct pax_nvme_device {
 	struct switchtec_dev *dev;
 	uint16_t pdfid;
-	int is_blk;
 	uint32_t ns_id;
 	uint32_t channel_status;
 	struct nvme_device device;

--- a/plugins/microchip/switchtec-nvme.c
+++ b/plugins/microchip/switchtec-nvme.c
@@ -75,7 +75,6 @@ int get_nvme_info(int fd, struct list_item *item, const char *node)
 	err = nvme_identify_ctrl(fd, &item->ctrl);
 	if (err)
 		return err;
-	item->nsid = nvme_get_nsid(fd);
 	if (item->nsid <= 0)
 		return item->nsid;
 	err = nvme_identify_ns(fd, item->nsid,
@@ -336,9 +335,10 @@ static int pax_build_nvme_pf_list(struct pax_nvme_device *pax,
 		if (!ret) {
 			for (k = 0; k < 1024; k++)
 				if (ns_list[k]) {
-					sprintf(node, "0x%04hxn%d@%s",
-						pax->pdfid, ns_list[k], path);
+					sprintf(node, "0x%04hx@%s",
+						pax->pdfid, path);
 					pax->ns_id = ns_list[k];
+					list_items[idx].nsid = ns_list[k];
 					ret = get_nvme_info(0,
 							    &list_items[idx++],
 							    node);


### PR DESCRIPTION
Made the following changes:
- delete `nXXXX` from `switchtec list` command output
- don't accept `nXXXX` in switchtec device string
- remove support for `get-ns-id` command: return error code
- delete unused `is_blk` field from `pax_nvme_device` structure

Output is shown below:
```
root@/switchtec-nvme-cli# ./switchtec-nvme switchtec list
Node                       SN                   Model                                    Namespace Usage                      Format           FW Rev
-------------------------- -------------------- ---------------------------------------- --------- -------------------------- ---------------- --------
0x3b00@/dev/switchtec0     S4YNNE0N800321       SAMSUNG MZWLJ1T9HBJR-00007               1           4.29  GB /   4.29  GB      4 KiB +  0 B   EPK9AJ5Q
0x3b00@/dev/switchtec0     S4YNNE0N800321       SAMSUNG MZWLJ1T9HBJR-00007               2           4.29  GB /   4.29  GB      4 KiB +  0 B   EPK9AJ5Q
0x3b00@/dev/switchtec0     S4YNNE0N800321       SAMSUNG MZWLJ1T9HBJR-00007               3           4.29  GB /   4.29  GB      4 KiB +  0 B   EPK9AJ5Q
0x1300@/dev/switchtec0     S4YNNE0N800316       SAMSUNG MZWLJ1T9HBJR-00007               1           4.29  GB /   4.29  GB      4 KiB +  0 B   EPK9AJ5Q
0x1300@/dev/switchtec0     S4YNNE0N800316       SAMSUNG MZWLJ1T9HBJR-00007               2           4.29  GB /   4.29  GB      4 KiB +  0 B   EPK9AJ5Q

root@/switchtec-nvme-cli# ./switchtec-nvme get-ns-id 0x3b00@/dev/switchtec0
Error: requesting namespace-id from non-block device
switchtec0: Block device required

root@/switchtec-nvme-cli# ./switchtec-nvme id-ctrl 0x3b00n1@/dev/switchtec0
Invalid device 0x3b00n1@/dev/switchtec0
Usage: nvme id-ctrl <device> [OPTIONS]

Send an Identify Controller command to the given device and report
...

```