### PR TITLE
Add `override` to LDFLAGS to ensure the assignment is not ignored

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ ifeq ($(HAVE_SYSTEMD),0)
 	override CFLAGS += -DHAVE_SYSTEMD
 endif
 
-LDFLAGS += -lswitchtec -lcrypto
+override LDFLAGS += -lswitchtec -lcrypto
 
 RPMBUILD = rpmbuild
 TAR = tar


### PR DESCRIPTION
From GNU (highlights mine)

> Variable assignments marked with the override flag have a higher priority than all other assignments, except another override. **Subsequent assignments or appends to this variable which are not marked override will be ignored.**

So line 41 must be prefixed with `override` otherwise both switchtec and crypto libraries are ignored.

Signed-off-by: Nate Roiger <nate.roiger@hpe.com>